### PR TITLE
chore: put Automatic-Module-Name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,10 @@ sourceSets {
 
 jar {
     exclude 'org/omegat/**'
+    exclude 'gen/**'
+    manifest {
+        attributes('Automatic-Module-Name': 'org.madlonkay.supertmxmerge')
+    }
 }
 
 task genJAXB(type: Exec) {


### PR DESCRIPTION
This change support use SuperTMXMerge with JPMS on Java 11, 17 or later.
It set "Automatic-Module-Name" attribute  to "org.madlonkay.supertmxmerge" in "META-INF/MANIFEST.MF"
Also adding exclude line to avoid  a generated "gen.omegat.tmx14" package in jar file. 

A attribute "Automatic-Module-Name" does not have no meaning in Java 8 but it will work in Java 9+.