### PR TITLE
chore: allow build from git export

### DIFF
--- a/.git-archival.properties
+++ b/.git-archival.properties
@@ -1,0 +1,3 @@
+node=$Format:%H$
+date=$Format:%cI$
+describe=$Format:%(describe:tags=true,match=[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 * text=auto
 *.sh text eol=lf
+.git-archival.properties  export-subst

--- a/build.gradle
+++ b/build.gradle
@@ -10,12 +10,20 @@ applicationName = 'SuperTMXMerge'
 mainClassName = 'org.madlonkay.supertmxmerge.Main'
 
 def getGitVersion = {
-    if (!file('.git').directory) {
-        return 'unknown'
+    if (file('.git').directory) {
+        StringBuilder output = new StringBuilder()
+        'git describe --tags --always HEAD'.execute().waitForProcessOutput(output, null)
+        return output.toString().trim()
+    } else {
+        def props = new Properties()
+        props.load(new FileInputStream(project.file(".git-archival.properties")))
+        def describe = props.getProperty('describe')
+        if (describe && describe ==~ /^\d+\.\d+\.\d+$/) {
+            return describe
+        } else {
+            return 'unknown'
+        }
     }
-    StringBuilder output = new StringBuilder()
-    'git describe --tags --always HEAD'.execute().waitForProcessOutput(output, null)
-    return output.toString().trim()
 }
 
 version = getGitVersion()


### PR DESCRIPTION
This change allows contributors, who download source tree from GitHub's download zip link, to build source with correct version.
